### PR TITLE
Fix image slider initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,10 +135,10 @@ ORIGINAL -----------------------I---------------------- IMPROVED
 
 <div class="img-comp-container">
   <div class="img-comp-img">
-    <img src="image2.jpg"  height="500">
+    <img src="image2.jpg" width="382" height="500">
   </div>
   <div class="img-comp-img img-comp-overlay">
-    <img src="image1.jpg" height="500">
+    <img src="image1.jpg" width="382" height="500">
   </div>
 </div>
 <p>&nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp Move the blue slider!</p>
@@ -149,10 +149,10 @@ ORIGINAL -----------------------I---------------------- IMPROVED
 ORIGINAL -----------------------I---------------------- IMPROVED
 <div class="img-comp-container">
   <div class="img-comp-img">
-    <img src="Flash2.jpg" height="400" alt="Image 3">
+    <img src="Flash2.jpg" width="399" height="400" alt="Image 3">
   </div>
   <div class="img-comp-img img-comp-overlay">
-    <img src="Flash1r.png" height="400" alt="Image 4">
+    <img src="Flash1r.png" width="399" height="400" alt="Image 4">
   </div>
 </div>
 <p> Our secret? </br>


### PR DESCRIPTION
For the slider script to work, the image container needs a fixed size. Otherwise the intrinsic size is 0 and it only works if the image is already served from cache at the time the script is executed.